### PR TITLE
・"catkin_make install"時にコピーするフォルダを指定

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ install(TARGETS
 # )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
-install(DIRECTORY launch cfg data
+install(DIRECTORY launch data
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   PATTERN ".svn" EXCLUDE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,7 @@ install(TARGETS
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
 install(DIRECTORY launch data
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-  PATTERN ".svn" EXCLUDE)
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 #############
 ## Testing ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,9 @@ add_dependencies(laserscan_virtualizer ${PROJECT_NAME}_gencfg)
 # )
 
 ## Mark executables and/or libraries for installation
-install(TARGETS laserscan_multi_merger laserscan_virtualizer
+install(TARGETS
+  laserscan_multi_merger
+  laserscan_virtualizer
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -134,9 +136,9 @@ install(TARGETS laserscan_multi_merger laserscan_virtualizer
 # )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
-install(DIRECTORY launch/
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
-)
+install(DIRECTORY launch cfg data
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  PATTERN ".svn" EXCLUDE)
 
 #############
 ## Testing ##


### PR DESCRIPTION
「ソフトウェアをソースコードの解析を難読化した状態で提供可能にする `https://github.com/LexxPluss/LexxAuto/issues/977`」の対応です。

### コミット内容
各パッケージのCMakeLists.txtへインストール関連の設定を追加（`http://wiki.ros.org/ja/catkin/CMakeLists.txt`に基づく）　

### 動作確認
フリートシステムからのjellyfishの操作→問題なし
フリートシステムからのsimulation2dロボットの操作→問題なし
通常ビルド（catkin_make）時と比べて、ロボット起動中のrosnode, rostopic, rosparam, rosservice, rosmsgのリスト内容に差異がないこと→問題なし