### PR TITLE
[#2130] Inf can be set out of range.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Hybrid-AMR changelog
+
+## Unreleased
+Inf can be set out of range. [#2130]

--- a/src/laserscan_multi_merger.cpp
+++ b/src/laserscan_multi_merger.cpp
@@ -49,7 +49,7 @@ private:
     double scan_time;
     double range_min;
     double range_max;
-    bool is_out_of_range_inf;
+    bool set_inf_to_the_points_exceed_range_max;
 
     string destination_frame;
     string cloud_destination_topic;
@@ -98,7 +98,7 @@ LaserscanMerger::LaserscanMerger()
     nh.param("scan_time", scan_time, 0.0333333);
     nh.param("range_min", range_min, 0.45);
     nh.param("range_max", range_max, 25.0);
-    nh.param("is_out_of_range_inf", is_out_of_range_inf, false);
+    nh.param("set_inf_to_the_points_exceed_range_max", set_inf_to_the_points_exceed_range_max, false);
 
     this->laserscan_topic_parser();
 
@@ -174,7 +174,7 @@ void LaserscanMerger::pointcloud_to_laserscan(Eigen::MatrixXf points, pcl::PCLPo
 	output->range_max = this->range_max;
 
 	uint32_t ranges_size = std::ceil((output->angle_max - output->angle_min) / output->angle_increment);
-	if (is_out_of_range_inf)
+	if (set_inf_to_the_points_exceed_range_max)
 	{
 		output->ranges.assign(ranges_size, std::numeric_limits<float>::infinity());
 	}

--- a/src/laserscan_multi_merger.cpp
+++ b/src/laserscan_multi_merger.cpp
@@ -49,7 +49,7 @@ private:
     double scan_time;
     double range_min;
     double range_max;
-	bool is_out_of_range_inf;
+    bool is_out_of_range_inf;
 
     string destination_frame;
     string cloud_destination_topic;

--- a/src/laserscan_multi_merger.cpp
+++ b/src/laserscan_multi_merger.cpp
@@ -49,6 +49,7 @@ private:
     double scan_time;
     double range_min;
     double range_max;
+	bool is_out_of_range_inf;
 
     string destination_frame;
     string cloud_destination_topic;
@@ -97,6 +98,7 @@ LaserscanMerger::LaserscanMerger()
     nh.param("scan_time", scan_time, 0.0333333);
     nh.param("range_min", range_min, 0.45);
     nh.param("range_max", range_max, 25.0);
+    nh.param("is_out_of_range_inf", is_out_of_range_inf, false);
 
     this->laserscan_topic_parser();
 
@@ -172,7 +174,14 @@ void LaserscanMerger::pointcloud_to_laserscan(Eigen::MatrixXf points, pcl::PCLPo
 	output->range_max = this->range_max;
 
 	uint32_t ranges_size = std::ceil((output->angle_max - output->angle_min) / output->angle_increment);
-	output->ranges.assign(ranges_size, output->range_max + 1.0);
+	if (is_out_of_range_inf)
+	{
+		output->ranges.assign(ranges_size, std::numeric_limits<float>::infinity());
+	}
+	else
+	{
+		output->ranges.assign(ranges_size, output->range_max + 1.0);
+	}
 
 	for(int i=0; i<points.cols(); i++)
 	{


### PR DESCRIPTION
Close LexxPluss/LexxAuto#2130
If scan is out of range, Inf can now set.
範囲外の時にInfを設定出来るように修正。