### PR TITLE
[AMRCS-9] Fix: Do not use points beyond range max.

### DIFF
--- a/src/laserscan_multi_merger.cpp
+++ b/src/laserscan_multi_merger.cpp
@@ -206,6 +206,13 @@ void LaserscanMerger::pointcloud_to_laserscan(pcl::PCLPointCloud2 *merged_cloud)
 			continue;
 		}
 
+		double range_max_sq_ = output->range_max * output->range_max;
+		if (range_max_sq_ <= range_sq)
+		{
+			ROS_DEBUG("rejected for range %f above maximum value %f. Point: (%f, %f, %f)", range_sq, range_max_sq_, x, y, z);
+			continue;
+		}
+
 		double angle = atan2(y, x);
 		if (angle < output->angle_min || angle > output->angle_max)
 		{


### PR DESCRIPTION
Fix AMRCS-9 
range max を超えた点群を観測した際に、値を上書きしていたため、範囲外のデータはInfを想定していたが range max よりも大きい実数が設定されていた為、範囲外のコストマップがクリアされなかった。