### PR TITLE
AMRSW-1132-handle-empty-intensity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Hybrid-AMR changelog
 
 ## Unreleased
+Handle empty intensity array. [AMRSW-115]
 Inf can be set out of range. [#2130]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Hybrid-AMR changelog
 
 ## Unreleased
-Handle empty intensity array. [AMRSW-115]
+Handle empty intensity array. [AMRSW-1132]
 Inf can be set out of range. [#2130]

--- a/src/laserscan_multi_merger.cpp
+++ b/src/laserscan_multi_merger.cpp
@@ -125,13 +125,23 @@ void LaserscanMerger::setAngleLimits(const sensor_msgs::LaserScan::ConstPtr& sca
 	filtered_scan.range_max = scan->range_max;
 	filtered_scan.angle_min = this->limit_angle_min;
 	filtered_scan.angle_max = this->limit_angle_max;
+    bool has_intensity = !scan->intensities.empty();
+
+    if (!has_intensity)
+    {
+		ROS_ERROR("Intensities array is empty in the LaserScan message.");
+    }
+
 	for (unsigned int i = 0; i < scan->ranges.size(); ++i)
 	{
 		float angle = scan->angle_min + i * scan->angle_increment;
 		if (angle >= this->limit_angle_min && angle <= this->limit_angle_max)
 		{
 			filtered_scan.ranges.push_back(scan->ranges[i]);
-			filtered_scan.intensities.push_back(scan->intensities[i]);
+			if (has_intensity)
+			{
+				filtered_scan.intensities.push_back(scan->intensities[i]);
+			}
 		}
 	}
 }

--- a/src/laserscan_multi_merger.cpp
+++ b/src/laserscan_multi_merger.cpp
@@ -130,6 +130,7 @@ void LaserscanMerger::setAngleLimits(const sensor_msgs::LaserScan::ConstPtr& sca
 	if (!has_intensity)
 	{
 		ROS_ERROR("Intensities array is empty in the LaserScan message.");
+		return;
 	}
 
 	for (unsigned int i = 0; i < scan->ranges.size(); ++i)

--- a/src/laserscan_multi_merger.cpp
+++ b/src/laserscan_multi_merger.cpp
@@ -125,12 +125,12 @@ void LaserscanMerger::setAngleLimits(const sensor_msgs::LaserScan::ConstPtr& sca
 	filtered_scan.range_max = scan->range_max;
 	filtered_scan.angle_min = this->limit_angle_min;
 	filtered_scan.angle_max = this->limit_angle_max;
-    bool has_intensity = !scan->intensities.empty();
+	bool has_intensity = !scan->intensities.empty();
 
-    if (!has_intensity)
-    {
+	if (!has_intensity)
+	{
 		ROS_ERROR("Intensities array is empty in the LaserScan message.");
-    }
+	}
 
 	for (unsigned int i = 0; i < scan->ranges.size(); ++i)
 	{


### PR DESCRIPTION
Closes AMRSW-1132

Add the ability to handle empty intensity array.

TESTS:
Used 63003
- [x] 24 hour tests with scan
![image](https://github.com/user-attachments/assets/074aa65e-32ca-4ea4-bfc3-da1992a8087d)

- [x] 24 hour tests with scan_hi
![image](https://github.com/user-attachments/assets/7aed5863-f8d1-4da2-9aab-75dc18a78848)
